### PR TITLE
feat: add pdf file compatibility to Minerva

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -805,6 +805,25 @@ files = [
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
+name = "pypdf2"
+version = "3.0.1"
+description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440"},
+    {file = "pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928"},
+]
+
+[package.extras]
+crypto = ["PyCryptodome"]
+dev = ["black", "flit", "pip-tools", "pre-commit (<2.18.0)", "pytest-cov", "wheel"]
+docs = ["myst_parser", "sphinx", "sphinx_rtd_theme"]
+full = ["Pillow", "PyCryptodome"]
+image = ["Pillow"]
+
+[[package]]
 name = "pyright"
 version = "1.1.403"
 description = "Command line wrapper for pyright"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pyparsing = "^3.1.4"
 lxml = {extras = ["html-clean"], version = "^5.3.0"}
 icalendar = "^5.0.13"
 recurring-ical-events = "^3.2.0"
+pypdf2 = "^3.0.1"
 
 [tool.poetry.group.dev.dependencies]
 lxml-stubs = "^0.5.1"


### PR DESCRIPTION
## How does this PR impact the user?

- Users can now upload PDF files to Minerva.
- Minerva acknowledges the uploaded file.
- Users can ask follow-up questions about the contents of the file.

Before:
<img width="1113" height="794" alt="image" src="https://github.com/user-attachments/assets/c0f28eb9-2975-48b2-b3e3-330f9c003952" />

After:
<img width="1113" height="794" alt="image" src="https://github.com/user-attachments/assets/e0e50b87-e453-49ee-a031-bc090935f2f9" />

## Description

- Added support for PDF file uploads in Minerva.
- When a user uploads a PDF file:
   - The bot reads the file content.
   - The bot acknowledges the upload without summarizing.
   - The user can ask follow-up questions about the file in the same session.
  (This feature is built on top of the .txt feature commit to make merge conflict easier)

Closes #23 

## Limitations

- No limitations

## Checklist

- [x] my PR is focused and contains one holistic change
- [x] I have added screenshots or screen recordings to show the changes
